### PR TITLE
feat: use jest/types in expect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ package-lock.json
 yarn.lock
 dist
 .vscode
+.env

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "typescript": "^4.4.3",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.7.2"
+  },
+  "dependencies": {
+    "@types/jest": ">=26.0.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import { default as expect } from 'expect'
 
-export default expect
+export default expect as jest.Expect


### PR DESCRIPTION
Instead of using `expect`, we ship jest.Expect from @types/jest

Co-authored-by: Norbert de Langen <norbert@chromatic.com>