### PR TITLE
Update expect to 28

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:esm": "ESM=true webpack --mode production",
     "build:cjs": "webpack --mode production",
     "postinstall": "patch-package",
-    "prepublish": "npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
     "@types/jest": "28.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "28.1.3-2",
+  "version": "28.1.3-3",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "expect": "28.1.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "patch-package": "^6.5.1",
-    "postinstall-postinstall": "^2.1.0",
     "release-it": "^14.11.5",
     "semver": "^7.3.5",
     "terser-webpack-plugin": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,5 @@
     "typescript": "^4.4.3",
     "webpack": "^5.50.0",
     "webpack-cli": "^4.7.2"
-  },
-  "dependencies": {
-    "@types/jest": ">=26.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "28.1.3-3",
+  "version": "28.1.3-4",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "28.1.3-1",
+  "version": "28.1.3-2",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "ESM=true webpack --mode production",
     "build:cjs": "webpack --mode production",
+    "postinstall": "patch-package",
     "prepublish": "npm run build"
   },
   "dependencies": {
@@ -31,6 +32,8 @@
     "execa": "^5.1.1",
     "expect": "28.1.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
+    "patch-package": "^6.5.1",
+    "postinstall-postinstall": "^2.1.0",
     "release-it": "^14.11.5",
     "semver": "^7.3.5",
     "terser-webpack-plugin": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "28.1.3-0",
+  "version": "28.1.3-1",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "28.1.3",
+  "version": "28.1.3-0",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",
@@ -24,6 +24,7 @@
     "prepublish": "npm run build"
   },
   "devDependencies": {
+    "@types/jest": "^28.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "execa": "^5.1.1",
     "expect": "28.1.3",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,10 @@
     "build:cjs": "webpack --mode production",
     "prepublish": "npm run build"
   },
+  "dependencies": {
+    "@types/jest": "28.1.3"
+  },
   "devDependencies": {
-    "@types/jest": "^28.0.0",
     "clean-webpack-plugin": "^4.0.0",
     "execa": "^5.1.1",
     "expect": "28.1.3",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "ESM=true webpack --mode production",
     "build:cjs": "webpack --mode production",
-    "postinstall": "patch-package",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "patch-package && npm run build"
   },
   "dependencies": {
     "@types/jest": "28.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@storybook/expect",
-  "version": "27.5.2-0",
+  "version": "28.1.3",
   "description": "Browser-compatible version of Jest's `expect`",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "clean-webpack-plugin": "^4.0.0",
     "execa": "^5.1.1",
-    "expect": "27.5.1",
+    "expect": "28.1.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
     "release-it": "^14.11.5",
     "semver": "^7.3.5",

--- a/patches/jest-util+28.1.3.patch
+++ b/patches/jest-util+28.1.3.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/jest-util/build/isInteractive.js b/node_modules/jest-util/build/isInteractive.js
+index bc25399..a8da3a5 100644
+--- a/node_modules/jest-util/build/isInteractive.js
++++ b/node_modules/jest-util/build/isInteractive.js
+@@ -22,6 +22,6 @@ function _ciInfo() {
+  * LICENSE file in the root directory of this source tree.
+  */
+ var _default =
+-  !!process.stdout.isTTY && process.env.TERM !== 'dumb' && !_ciInfo().isCI;
++  !!process.stdout && !!process.stdout.isTTY && process.env.TERM !== 'dumb' && !_ciInfo().isCI;
+ 
+ exports.default = _default;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import { default as expect } from 'expect'
 
-export default expect as jest.Expect
+export default expect

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 import { default as expect } from 'expect'
 
-export default expect
+export default (expect as any) as jest.Expect

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import { default as expect } from 'expect'
+import { default as expect } from "expect"
 
-export default (expect as any) as jest.Expect
+export default expect as any as jest.Expect

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { default as expect } from "expect"
 
+// @testing-library/jest-dom enhances jest.Expect with e.g. `toBeInTheDocument`
 export default expect as any as jest.Expect


### PR DESCRIPTION
I also removed the typecast, but I'm not certain if that will cause problems.  It seems like we shouldn't be changing the type, if all we're doing is re-exporting a version of the package that works in the browser.