### PR TITLE
Use correct extension for ESM (.mjs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "type": "git",
     "url": "https://github.com/storybookjs/expect.git"
   },
-  "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
   "license": "MIT",
   "files": [
     "dist/**/*"
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "dev": "ESM=true webpack --watch --mode development",
-    "build": "npm run build:esm && npm run build:cjs",
+    "build": "rimraf dist && npm run build:esm && npm run build:cjs",
     "build:esm": "ESM=true webpack --mode production",
     "build:cjs": "webpack --mode production",
     "prepublishOnly": "patch-package && npm run build"
@@ -33,6 +33,7 @@
     "node-polyfill-webpack-plugin": "^1.1.4",
     "patch-package": "^6.5.1",
     "release-it": "^14.11.5",
+    "rimraf": "^5.0.1",
     "semver": "^7.3.5",
     "terser-webpack-plugin": "^5.1.4",
     "ts-loader": "^9.2.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "scripts": {
     "dev": "ESM=true webpack --watch --mode development",
-    "build": "rimraf dist && npm run build:esm && npm run build:cjs",
+    "prebuild": "rimraf dist",
+    "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "ESM=true webpack --mode production",
     "build:cjs": "webpack --mode production",
     "prepublishOnly": "patch-package && npm run build"
@@ -35,7 +36,6 @@
     "@types/jest": "28.1.3"
   },
   "devDependencies": {
-    "clean-webpack-plugin": "^4.0.0",
     "execa": "^5.1.1",
     "expect": "28.1.3",
     "node-polyfill-webpack-plugin": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
   "files": [
     "dist/**/*"
   ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./package.json": "./package.json"
+  },
   "types": "dist/types/index.d.ts",
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
     ".": {
       "require": "./dist/index.js",
       "import": "./dist/index.mjs",
-      "types": "./dist/types/index.d.ts"
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json"
   },
-  "types": "dist/types/index.d.ts",
+  "types": "dis/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     },
     "./package.json": "./package.json"
   },
-  "types": "dis/index.d.ts",
+  "types": "dist/index.d.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "declarationDir": "./dist/types",
+    "declarationDir": "./dist",
   },
   "include": ["src/*.ts"],
   "exclude": ["node_modules"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,5 @@
 const NodePolyfillPlugin = require("node-polyfill-webpack-plugin")
 const TerserPlugin = require("terser-webpack-plugin")
-const { CleanWebpackPlugin } = require("clean-webpack-plugin")
 const path = require("path")
 
 module.exports = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,8 @@ module.exports = {
     ],
   },
   output: {
-    filename: 'index.js',
-    path: path.resolve(__dirname, 'dist', process.env.ESM ? 'esm' : 'cjs'),
+    filename: process.env.ESM ? 'index.mjs' : 'index.js',
+    path: path.resolve(__dirname, 'dist'),
     library: {
       type: process.env.ESM ? 'module' : 'commonjs'
     }
@@ -39,7 +39,6 @@ module.exports = {
     chunkIds: "named",
   },
   plugins: [
-    new CleanWebpackPlugin(),
     new NodePolyfillPlugin()
   ],
   resolve: {


### PR DESCRIPTION
Since we do not set `"type": "module"` in the package.json file, `.js` extensions are considered commonjs by node.  This PR adds the correct extension for the ESM bundle.

It also adds an `"exports"` map to the package.json, for improved support with tools like vitest, which do not respect the non-standard `"module"` field by default.